### PR TITLE
Change GBA to GameBoy Advance in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # gba
 
-A crate that helps you make GBA games
+A crate that helps you make GameBoy Advance (GBA) games
 
 # First Time Setup
 


### PR DESCRIPTION
I saw somebody on twitter saying they couldn't figure out what GBA stands for.
Given that full name isn't currently used anywhere, this change could help people not familiar video games abbreviations.