### PR TITLE
SioSerial improvements

### DIFF
--- a/examples/uart_echo.rs
+++ b/examples/uart_echo.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![no_main]
+#![feature(start)]
 
 //      _      Link Cable Pinout
 //  ___/ \___  1: VCC - 3.3V
@@ -20,8 +20,7 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 
 #[start]
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
-  let mut serial = SioSerial;
-  SioSerial::init(BaudRate::Bps115200);
+  let mut serial = SioSerial::init(BaudRate::Bps115200);
 
   loop {
     if let Ok(c) = block!(serial.read()) {

--- a/src/io/sio.rs
+++ b/src/io/sio.rs
@@ -124,12 +124,13 @@ newtype_enum! {
 
 /// Empty stuct that implements embedded_hal traits.
 #[cfg(feature = "serial")]
+#[derive(Clone)]
 pub struct SioSerial;
 
 #[cfg(feature = "serial")]
 impl SioSerial {
   /// Initialize SioSerial with provided baud rate and default 8N1 settings.
-  pub fn init(baud: BaudRate) {
+  pub fn init(baud: BaudRate) -> Self {
     RCNT.write(IoControlSetting::new());
     SIOCNT.write(
       // default settings: 8N1
@@ -137,14 +138,18 @@ impl SioSerial {
         .with_baud_rate(baud)
         .with_data_length_8bit(true)
         .with_mode(SioMode::Uart)
+        .with_fifo_enable(true)
         .with_rx_enable(true)
         .with_tx_enable(true),
     );
+
+    SioSerial
   }
 }
 
 /// Serial IO error type.
 #[cfg(feature = "serial")]
+#[derive(Debug)]
 pub enum SioError {
   /// * Error bit in SIOCNT is set
   ErrorBitSet,


### PR DESCRIPTION
Make a few improvements to the SioSerial struct:
- Have init() return Self. It's more ergonomic to create and initialize
the empty struct in one call.
- Enable FIFO. The GBA has a 4-byte UART FIFO. This makes it less
likely to lose received bytes.
- Derive Clone on SioSerial so it can be split and shared with an
interrupt.
- Derive Debug on SioError so results can be unwrapped.