### PR TITLE
Add a `get_screen_block` function to the `vram` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 # The crt0.o file should, under the currently suggested build scheme, be
 # recompiled every build anyway.
 crt0.o
+
+# Don't track VSCode Workspace settings
+/.vscode

--- a/src/vram.rs
+++ b/src/vram.rs
@@ -15,7 +15,7 @@
 
 pub(crate) use super::*;
 
-use typenum::consts::{U256, U32, U512, U6};
+use typenum::{U1024, consts::{U256, U32, U512, U6}};
 
 pub mod affine;
 pub mod bitmap;
@@ -58,4 +58,8 @@ pub fn get_4bpp_character_block(slot: usize) -> VolBlock<Tile4bpp, U512> {
 /// Gives the specified charblock in 8bpp view.
 pub fn get_8bpp_character_block(slot: usize) -> VolBlock<Tile8bpp, U256> {
   unsafe { VolBlock::new(CHAR_BASE_BLOCKS.index(slot).to_usize()) }
+}
+
+pub fn get_screen_block(slot: usize) -> VolBlock<TextScreenblockEntry, U1024> {
+  unsafe { VolBlock::new(SCREEN_BASE_BLOCKS.index(slot).to_usize()) }
 }


### PR DESCRIPTION
This simplifies working with tiles as currently there is no easy way to manipulate single tiles using `SCREEN_BASE_BLOCKS`