### PR TITLE
Add the `Static<T>` type to make global mutable state easier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 //! **Do not** use this crate in programs that aren't running on the GBA. If you
 //! do, it's a giant bag of Undefined Behavior.
 
+use core::{cell::Cell, fmt, cmp::Ordering};
+
 pub(crate) use gba_proc_macro::phantom_fields;
 pub(crate) use voladdress::{read_only::ROVolAddress, VolAddress, VolBlock};
 
@@ -180,6 +182,169 @@ pub unsafe fn divrem_i32_unchecked(numer: i32, denom: i32) -> (i32, i32) {
     (false, false) => (udiv as i32, urem as i32),
   }
 }
+
+/// A memory safe type to allow for global mutable static variables.
+/// 
+/// The way it achieves memory safety is similar to [`Cell<T>`]:
+/// It never allows you to transform a `&Static<T>` to a `&T`. That way
+/// you can never have reference invalidation because you can only ever get
+/// a reference to the inner value if you have exclusive access to the `Static<T>`.
+/// Additionally, because the GBA doesn't have hardware threads, data races are
+/// impossible, so we can safely implement [`Sync`](core::sync::Sync) for this type, whereas
+/// [`Cell<T>`] cannot.
+///
+/// Under the hood this type uses [`Cell<T>`] so it can't have implementation errors
+/// that lead to unsoundness (unless the core library implementation is wrong).
+///
+/// # Examples
+///
+/// ```ignore
+/// static IRQ_COUNTER: Static<usize> = Static::new(0);
+/// 
+/// extern "C" fn irq_handler(_: IrqFlags) {
+///   IRQ_COUNTER.set(COUNTER.get() + 1);   
+/// }
+///```
+/// 
+/// This example just counts the number of interrupt requests which normally
+/// you wouldn't be able to without using `unsafe` code.
+/// 
+/// [`Cell<T>`]: core::cell::Cell
+#[repr(transparent)]
+pub struct Static<T: ?Sized> {
+  inner: Cell<T>,
+}
+
+impl<T> Static<T> {
+  /// Constructs a new `Static<T>` with a given value.
+  pub const fn new(value: T) -> Self {
+    Self { inner: Cell::new(value) }
+  }
+
+  /// Replaces the current value with the given one.
+  pub fn set(&self, value: T) {
+    self.inner.set(value);
+  }
+
+  /// Swaps the two inner values. The advantage over simply using
+  /// [`core::mem::swap`] is that you don't need exclusive access to the values.
+  pub fn swap(&self, other: &Static<T>) {
+    self.inner.swap(&other.inner);
+  }
+
+  /// Replaces the current value with the given one and returns it.
+  pub fn replace(&self, value: T) -> T {
+    self.inner.replace(value)
+  }
+
+  /// Consumes the `Static<T>` and returns the current inner value.
+  pub fn into_inner(self) -> T {
+    self.inner.into_inner()
+  }
+}
+
+impl<T: Copy> Static<T> {
+  /// Returns a copy of the current inner value.
+  pub fn get(&self) -> T {
+    self.inner.get()
+  }
+
+  /// Updates the inner value using the given function
+  /// and returns the new inner value.
+  pub fn update<F: FnOnce(T) -> T>(&self, f: F) -> T {
+    let old = self.get();
+    let new = f(old);
+    self.set(new);
+    new
+  }
+}
+
+impl<T: ?Sized> Static<T> {
+  /// Returns a pointer to the inner value.
+  pub const fn as_ptr(&self) -> *mut T {
+    self.inner.as_ptr()
+  }
+
+  /// Returns a mutable reference to the inner value.
+  /// This is safe, as it requires exclusive access to the `Static<T>`,
+  /// so noone else can set the inner value which could lead
+  /// to reference invalidation
+  pub fn get_mut(&mut self) -> &mut T {
+    self.inner.get_mut()
+  }
+
+  /// Returns a reference to `Static<T>` from a `&mut T`.
+  /// This is safe because during the lifetime of the `&Static<T>`
+  /// it has exclusive access to the `&mut T`
+  pub fn from_mut(t: &mut T) -> &Static<T> {
+    unsafe { &*(t as *mut T as *const Static<T>) }
+  }
+}
+
+impl<T: Default> Static<T> {
+  /// Returns the inner value and replaces it with [`<T as Default>::default()`](core::default::Default::default).
+  pub fn take(&self) -> T {
+    self.replace(Default::default())
+  }
+}
+
+impl<T: fmt::Debug + Copy> fmt::Debug for Static<T> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_tuple("Static").field(&self.get()).finish()
+  }
+}
+
+impl<T: Default> Default for Static<T> {
+  fn default() -> Self {
+    Self::new(Default::default())
+  }
+}
+
+impl<T: PartialEq + Copy> PartialEq for Static<T> {
+  fn eq(&self, other: &Self) -> bool {
+    self.get().eq(&other.get())
+  }
+
+  fn ne(&self, other: &Self) -> bool {
+    self.get().ne(&other.get())
+  }
+}
+
+impl<T: Eq + Copy> Eq for Static<T> {
+  fn assert_receiver_is_total_eq(&self) {}
+}
+
+impl<T> From<T> for Static<T> {
+  fn from(value: T) -> Self {
+    Self::new(value)
+  }
+}
+
+impl<T: PartialOrd + Copy> PartialOrd for Static<T> {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    self.get().partial_cmp(&other.get())
+  }
+
+  fn lt(&self, other: &Self) -> bool {
+    self.get().lt(&other.get())
+  }
+  
+  fn le(&self, other: &Self) -> bool {
+    self.get().le(&other.get())
+  }
+  
+  fn gt(&self, other: &Self) -> bool {
+    self.get().gt(&other.get())
+  }
+  
+  fn ge(&self, other: &Self) -> bool {
+    self.get().ge(&other.get())
+  }
+}
+
+// SAFETY: Because the GBA doesn't have hardware threads, data races are impossible, so this implementation is sound
+// (Note that it's only sound if it's actually run on a GBA)
+unsafe impl<T> Sync for Static<T> {}
 
 /*
 #[cfg(test)]

--- a/src/static_types.rs
+++ b/src/static_types.rs
@@ -1,0 +1,414 @@
+//! Module containing types that allow for mutable statics.
+
+use core::{
+  cell::UnsafeCell,
+  cmp::Ordering,
+  fmt, ptr,
+  sync::atomic::{fence, Ordering::AcqRel},
+};
+
+macro_rules! impl_static {
+  ($i: ident, $ty: ty) => {
+    impl_static!($i, $ty, stringify!($i));
+  };
+
+  ($i: ident, $ty: ty, $n: expr) => {
+    #[repr(transparent)]
+    /// A static type with interior mutability
+    pub struct $i {
+      inner: UnsafeCell<$ty>,
+    }
+
+    impl $i {
+      #[inline(always)]
+      /// Creates a new static value
+      pub const fn new(val: $ty) -> Self {
+        Self { inner: UnsafeCell::new(val) }
+      }
+
+      #[inline(always)]
+      /// Sets the inner value and discards the old value
+      pub fn set(&self, val: $ty) {
+        self.replace(val);
+      }
+
+      #[inline(always)]
+      /// Swaps the two inner values without requiring exclusive access
+      pub fn swap(&self, other: &Self) {
+        if !ptr::eq(self, other) {
+          unsafe { ptr::swap_nonoverlapping(self.inner.get(), other.inner.get(), 1) }
+          fence(AcqRel)
+        }
+      }
+
+      #[inline(always)]
+      /// Sets the inner value and returns the old value
+      pub fn replace(&self, val: $ty) -> $ty {
+        unsafe {
+          let old_val = self.inner.get().read_volatile();
+          self.inner.get().write_volatile(val);
+          fence(AcqRel);
+          old_val
+        }
+      }
+
+      #[inline(always)]
+      /// Returns a copy of the inner value
+      pub fn get(&self) -> $ty {
+        let inner = unsafe { self.inner.get().read_volatile() };
+        fence(AcqRel);
+        inner
+      }
+
+      #[inline(always)]
+      /// Updates the inner value using the given function and returns a copy of the updated value
+      pub fn update<F: FnOnce($ty) -> $ty>(&self, f: F) -> $ty {
+        let old_val = self.get();
+        let new_val = f(old_val);
+        self.set(new_val);
+        new_val
+      }
+
+      #[inline(always)]
+      /// Returns the inner value and replaces it with the default value
+      pub fn take(&self) -> $ty {
+        self.replace(<$ty>::default())
+      }
+    }
+
+    impl Clone for $i {
+      fn clone(&self) -> Self {
+        Self::new(self.get())
+      }
+    }
+
+    impl fmt::Debug for $i {
+      fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple(stringify!(i)).field(&self.get()).finish()
+      }
+    }
+
+    impl Default for $i {
+      fn default() -> Self {
+        Self::new(<$ty>::default())
+      }
+    }
+
+    impl Eq for $i {}
+
+    impl PartialEq for $i {
+      fn eq(&self, rhs: &Self) -> bool {
+        self.get() == rhs.get()
+      }
+    }
+
+    impl Ord for $i {
+      fn cmp(&self, rhs: &Self) -> Ordering {
+        self.get().cmp(&rhs.get())
+      }
+    }
+
+    impl PartialOrd for $i {
+      fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
+        Some(self.cmp(rhs))
+      }
+    }
+
+    // SAFETY: Because the GBA doesn't have hardware threads, data races are impossible
+    unsafe impl Sync for $i {}
+  };
+}
+
+impl_static!(StaticBool, bool);
+impl_static!(StaticI8, i8);
+impl_static!(StaticU8, u8);
+impl_static!(StaticI16, i16);
+impl_static!(StaticU16, u16);
+impl_static!(StaticI32, i32);
+impl_static!(StaticU32, u32);
+impl_static!(StaticIsize, isize);
+impl_static!(StaticUsize, usize);
+
+/// A type representing a static mutable memory location.
+///
+/// The way it achieves memory safety is very similar to [`Cell<T>`](core::cell::Cell):
+/// It never allows you to get a reference to whats inside the `Static<T>`.
+/// The only way to get the inner value is to either copy it out of there
+/// or to replace it with another value. That way, you can never get reference
+/// invalidation from overwriting the inner value. Also, for this type to be
+/// safe to use both inside the interrupt handler and the main program, it has
+/// to carry an extra flag with it. The reason for this is that if `size_of::<T>() > size_of::<usize>()`,
+/// the CPU can't write the entire value in a single instruction, so the write can be interrupted
+/// by in IRQ. That way you could get data tearing when reading the value inside the IRQ handler,
+/// so we have to make sure that you can only access the inner value if it's not currently being written to.
+/// 
+/// ## NOTE
+/// 
+/// If you want a static value that fits inside a `usize`, ***don't*** use this type. If you want
+/// to have a static primitive (bool, i8, u8, ..., usize), use the StaticT versions of those (for example [`StaticBool`]).
+/// If you want a static variable of a custom type that fits in one word, use [`StaticWord<T>`] instead.
+/// The reason for that is that this type carries a runtime overhead because it needs to check for
+/// availability on every read/write. This availability check also makes the API more complicated to use.
+/// 
+/// # Examples
+/// 
+/// ```ignore
+/// 
+/// struct State([u8; 5]);
+/// 
+/// static STATE: Static<State> = Static::new(State([0; 5]));
+/// 
+/// extern "C" fn irq_handler(flags: IrqFlags) {
+///   STATE.try_set([1, 2, 3, 4, 5]);
+/// } 
+/// 
+/// fn main() {
+///   set_irq_handler(irq_handler);
+///   while STATE.try_get().unwrap_or([0; 5])[1] == 0 {}
+///   debug!("STATE changed!");
+/// }
+/// ```
+/// 
+/// This admittedly very unrealistic example shows that you can use the `Static<T>` both in the IRQ handler and
+/// in the main program and the types aren't constrained to primitives.
+pub struct Static<T> {
+  available: StaticBool,
+  inner: UnsafeCell<T>,
+}
+
+impl<T> Static<T> {
+  #[inline(always)]
+  /// Constructs a new `Static<T>` with the given value.
+  pub const fn new(val: T) -> Self {
+    Self { available: StaticBool::new(true), inner: UnsafeCell::new(val) }
+  }
+
+  #[inline(always)]
+  /// Tries to set the inner value to the given one.
+  /// 
+  /// If this succeeds, the method returns `Ok(())`.
+  /// If it fails, the method returns `Err(val)`, where `val` is the function argument
+  pub fn try_set(&self, val: T) -> Result<(), T> {
+    self.try_replace(val).map(|_| ())
+  }
+
+  /// Tries to replace the inner value with the given one.
+  /// 
+  /// If this succeeds, the method returns `Ok(old_val)`, where `old_val` is the previous inner value.
+  /// If it fails, it returns `Err(val)`, where `val` is the function argument
+  pub fn try_replace(&self, val: T) -> Result<T, T> {
+    if self.available.get() {
+      self.available.set(false);
+      let old_val = unsafe {
+        let old_val = self.inner.get().read_volatile();
+        self.inner.get().write_volatile(val);
+        old_val
+      };
+      self.available.set(true);
+      fence(AcqRel);
+      Ok(old_val)
+    } else {
+      Err(val)
+    }
+  }
+
+  #[inline(always)]
+  /// Tries to extract the inner value by consuming the `Static<T>`.
+  /// 
+  /// If this succeeds, it returns `Ok(inner)`
+  /// If it fails, it returns `Err(self)`
+  pub fn try_into_inner(self) -> Result<T, Self> {
+    if self.available.get() {
+      Ok(self.inner.into_inner())
+    } else {
+      Err(self)
+    }
+  }
+}
+
+impl<T: Copy> Static<T> {
+  /// Tries to copy the inner value.
+  /// 
+  /// If this fails, the method will return `None`
+  pub fn try_get(&self) -> Option<T> {
+    if self.available.get() {
+      self.available.set(false);
+      let v = unsafe { self.inner.get().read_volatile() };
+      self.available.set(true);
+      fence(AcqRel);
+      Some(v)
+    } else {
+      None
+    }
+  }
+
+  /// Tries to update the inner value using the given function.
+  /// 
+  /// If this fails, the method will return `None`
+  pub fn try_update<F: FnOnce(T) -> T>(&self, f: F) -> Option<T> {
+    let old_val = self.try_get()?;
+    let new_val = f(old_val);
+    self.try_set(new_val).ok()?;
+    Some(new_val)
+  }
+}
+
+impl<T: Default> Default for Static<T> {
+  fn default() -> Self {
+    Self::new(T::default())
+  }
+}
+
+// SAFETY: Because `Static<T>` checks for availability before every operation, data races cannot occur
+unsafe impl<T> Sync for Static<T> {}
+
+#[repr(transparent)]
+/// A mutable static memory location that fits inside one machine word.
+/// 
+/// This works pretty similarly to [`Static<T>`](self::Static), except that it doesn't have the
+/// associated runtime overhead and complicated API. This is because `StaticWord<T>` only
+/// allows for inner types that fit in one machine word (`usize`), so an IRQ can't happen
+/// during a write to the inner value. Because of that data tearing cannot happen so we don't
+/// have to check for it.
+/// 
+/// ## NOTE:
+/// 
+/// If you use this type with a `T` which is larger than one word, the constructor will panic at
+/// runtime. This is because rust currently doesn't allow for const assertions, so we can't check
+/// that `size_of::<T>() <= size_of::<usize>()` at compile time.
+/// 
+/// # Example:
+/// 
+/// ```ignore
+/// 
+/// #[derive(PartialEq, Copy, Clone)]
+/// enum State {
+///   Alive,
+///   Dead
+/// }
+/// 
+/// static STATE: Static<State> = Static::new(State::Alive);
+/// 
+/// extern "C" fn irq_handler(flags: IrqFlags) {
+///   STATE.set(State::Dead)
+/// }
+/// 
+/// fn main() {
+///   set_irq_handler(irq_handler);
+///   while STATE.get() == State::Alive {}
+///   debug!("You died!");
+/// }
+/// ```
+/// 
+/// This example shows that it's possible to use the static variable from the IRQ handler
+/// and the main program
+pub struct StaticWord<T> {
+  inner: UnsafeCell<T>,
+}
+
+impl<T> StaticWord<T> {
+  #[inline(always)]
+  /// Constructs a new `StaticWord<T>` with the given type.
+  /// 
+  /// ## NOTE:
+  /// If the size of the inner type is larger than a word, this
+  /// function will panic with a very ugly panic message.
+  /// This is because currently there's no proper way to assert
+  /// things in a `const fn`
+  pub const fn new(val: T) -> Self {
+    // An ugly way of asserting that `T` is not larger that a word.
+    // This panics at runtime if `T` is too large.
+    // Obviously a compile time check would be way preferable,
+    // but that's not possible in current stable rust
+    [()][(core::mem::size_of::<T>() > core::mem::size_of::<usize>()) as usize];
+    Self { inner: UnsafeCell::new(val) }
+  }
+
+  #[inline(always)]
+  /// Sets the inner value and discards the old value.
+  pub fn set(&self, val: T) {
+    self.replace(val);
+  }
+
+  #[inline(always)]
+  /// Swaps the contents of the two `StaticWord<T>`.
+  /// Unlike [`core::mem::swap`] this doesn't require exclusive access
+  pub fn swap(&self, other: &Self) {
+    if !ptr::eq(self, other) {
+      unsafe {
+        ptr::swap_nonoverlapping(self.inner.get(), other.inner.get(), 1);
+        fence(AcqRel)
+      }
+    }
+  }
+
+  /// Sets the new inner value and returns the old value.
+  pub fn replace(&self, val: T) -> T {
+    unsafe {
+      let old_val = self.inner.get().read_volatile();
+      self.inner.get().write_volatile(val);
+      fence(AcqRel);
+      old_val
+    }
+  }
+
+  #[inline(always)]
+  /// Consumes the `StaticWord<T>` and returns the inner value.
+  pub fn into_inner(self) -> T {
+    self.inner.into_inner()
+  }
+}
+
+impl<T: Copy> StaticWord<T> {
+  #[inline(always)]
+  /// Copies the inner value and returns it.
+  pub fn get(&self) -> T {
+    let v = unsafe { self.inner.get().read_volatile() };
+    fence(AcqRel);
+    v
+  }
+
+  /// Updates the inner value with the given function and returns the new inner value.
+  pub fn update<F: FnOnce(T) -> T>(&self, f: F) -> T {
+    let old_val = self.get();
+    let new_val = f(old_val);
+    self.set(new_val);
+    old_val
+  }
+}
+
+impl<T: Default> StaticWord<T> {
+  /// Replaces the inner value with the default value.
+  pub fn take(&self) -> T {
+    self.replace(T::default())
+  }
+}
+
+impl<T: Copy> Clone for StaticWord<T> {
+  fn clone(&self) -> Self {
+    Self::new(self.get())
+  }
+}
+
+impl<T: Copy + Eq> Eq for StaticWord<T> {}
+
+impl<T: Copy + PartialEq> PartialEq for StaticWord<T> {
+  fn eq(&self, rhs: &Self) -> bool {
+    self.get() == rhs.get()
+  }
+}
+
+impl<T: Copy + Ord> Ord for StaticWord<T> {
+  fn cmp(&self, rhs: &Self) -> Ordering {
+    self.get().cmp(&rhs.get())
+  }
+}
+
+impl<T: Copy + PartialOrd> PartialOrd for StaticWord<T> {
+  fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
+    self.get().partial_cmp(&rhs.get())
+  }
+}
+
+// SAFETY: Because the GBA doesn't have hardware threads, data races are impossible
+unsafe impl<T: Copy> Sync for StaticWord<T> {}


### PR DESCRIPTION
This is useful for example when setting a flag inside an interrupt handler to then execute something later. This was previously only possible using `static mut` variables, which can't be accessed safely and can lead to memory unsoundness like reference invalidation.