### PR TITLE
Added .iwram section

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -32,6 +32,14 @@ SECTIONS {
         __bss_end = ABSOLUTE(.);
     } >iwram
 
+    __iwram_lma = .;
+    .iwram : {
+        __iwram_start = ABSOLUTE(.);
+        *(.iwram .iwram.*);
+        . = ALIGN(4);
+        __iwram_end = ABSOLUTE(.);
+    } >iwram
+
     /* debugging sections */
     /* Stabs */
     .stab            0 : { *(.stab) }

--- a/linker.ld
+++ b/linker.ld
@@ -18,26 +18,27 @@ SECTIONS {
         . = ALIGN(4);
     } >rom = 0xff
 
-    __data_lma = .;
-    .data : {
+    __iwram_lma = .;
+    .iwram : {
+        __iwram_start = ABSOLUTE(.);
+        
         __data_start = ABSOLUTE(.);
         *(.data .data.*);
         . = ALIGN(4);
         __data_end = ABSOLUTE(.);
+        
+        __text_iwram_start = ABSOLUTE(.);
+        *(.text_iwram .text_iwram.*);
+        . = ALIGN(4);
+        __text_iwram_end = ABSOLUTE(.);
+        
+        __iwram_end = ABSOLUTE(.);
     } >iwram AT>rom = 0xff
 
     .bss : {
         *(.bss .bss.*);
         . = ALIGN(4);
         __bss_end = ABSOLUTE(.);
-    } >iwram
-
-    __iwram_lma = .;
-    .iwram : {
-        __iwram_start = ABSOLUTE(.);
-        *(.iwram .iwram.*);
-        . = ALIGN(4);
-        __iwram_end = ABSOLUTE(.);
     } >iwram
 
     /* debugging sections */

--- a/src/rsrt0.S
+++ b/src/rsrt0.S
@@ -21,19 +21,7 @@ __start:
     msr CPSR_c, r0
     ldr sp, =0x3007f00
 
-    @ copy .data section to IWRAM
-    ldr r0, =__data_lma     @ source address
-    ldr r1, =__data_start   @ destination address
-    ldr r2, =__data_end
-    subs r2, r1             @ length
-    @ these instructions are only executed if r2 is nonzero
-    @ (i.e. don't bother copying an empty .data section)
-    addne r2, #3
-    asrne r2, #2
-    addne r2, #0x04000000
-    swine 0xb0000
-
-    @ copy .iwram section to IWRAM
+    @ copy .data and .text_iwram section to IWRAM
     ldr r0, =__iwram_lma     @ source address
     ldr r1, =__iwram_start   @ destination address
     ldr r2, =__iwram_end

--- a/src/rsrt0.S
+++ b/src/rsrt0.S
@@ -33,6 +33,18 @@ __start:
     addne r2, #0x04000000
     swine 0xb0000
 
+    @ copy .iwram section to IWRAM
+    ldr r0, =__iwram_lma     @ source address
+    ldr r1, =__iwram_start   @ destination address
+    ldr r2, =__iwram_end
+    subs r2, r1             @ length
+    @ these instructions are only executed if r2 is nonzero
+    @ (i.e. don't bother copying an empty .iwram section)
+    addne r2, #3
+    asrne r2, #2
+    addne r2, #0x04000000
+    swine 0xb0000
+
     @ jump to user code
     ldr r0, =main
     bx r0


### PR DESCRIPTION
I've duplicated the copying asm that was used for `.data`. Unfortunately, my ARM assembly is a rusty so I'm not certain as to whether this has the intended effect.

Follow-up from https://github.com/rust-console/gba/issues/113 .