### PR TITLE
Bitfield fixes

### DIFF
--- a/src/mmio_types.rs
+++ b/src/mmio_types.rs
@@ -15,13 +15,13 @@ macro_rules! bitfield_int {
   ($inner:ty; $low:literal ..= $high:literal : $nt:ident, $get:ident, $with:ident, $set:ident) => {
     #[inline]
     pub const fn $get(self) -> $nt {
-      const MASK: $inner = ((1 << $high) - 1) << $low;
+      const MASK: $inner = ((1 << ($high - $low + 1)) - 1) << $low;
       ((self.0 & MASK) >> $low) as $nt
     }
     #[inline]
     pub const fn $with(self, $get: $nt) -> Self {
-      const MASK: $inner = ((1 << $high) - 1) << $low;
-      Self(self.0 ^ ((self.0 ^ ($get as $inner)) & MASK))
+      const MASK: $inner = ((1 << ($high - $low + 1)) - 1) << $low;
+      Self(self.0 ^ ((self.0 ^ (($get as $inner) << $low)) & MASK))
     }
     #[inline]
     pub fn $set(&mut self, $get: $nt) {
@@ -36,12 +36,12 @@ macro_rules! bitfield_newtype {
   ($inner:ty; $low:literal ..= $high:literal : $nt:ident, $get:ident, $with:ident, $set:ident) => {
     #[inline]
     pub const fn $get(self) -> $nt {
-      const MASK: $inner = ((1 << $high) - 1) << $low;
+      const MASK: $inner = ((1 << ($high - $low + 1)) - 1) << $low;
       $nt(self.0 & MASK)
     }
     #[inline]
     pub const fn $with(self, $get: $nt) -> Self {
-      const MASK: $inner = ((1 << $high) - 1) << $low;
+      const MASK: $inner = ((1 << ($high - $low + 1)) - 1) << $low;
       Self(self.0 ^ ((self.0 ^ $get.0) & MASK))
     }
     #[inline]

--- a/src/mmio_types/timer_control.rs
+++ b/src/mmio_types/timer_control.rs
@@ -6,7 +6,7 @@ pub struct TimerControl(u8);
 impl TimerControl {
   const_new!();
   bitfield_int!(u8; 0..=1: u8, prescaler_selection, with_prescaler_selection, set_prescaler_selection);
-  bitfield_bool!(u8; 4, chained_counting, with_chained_counting, set_chained_counting);
+  bitfield_bool!(u8; 2, chained_counting, with_chained_counting, set_chained_counting);
   bitfield_bool!(u8; 6, irq_on_overflow, with_irq_on_overflow, set_irq_on_overflow);
   bitfield_bool!(u8; 7, enabled, with_enabled, set_enabled);
 }


### PR DESCRIPTION
There were a few errors in the `mmio_types` macros and `TimerControl` definition that were breaking the timestamps in `test_savegame`. This fixes those issues.

Fixes #145.