### PR TITLE
Sets an initial WAITCNT in rsrt0.S

### DIFF
--- a/src/rsrt0.S
+++ b/src/rsrt0.S
@@ -23,6 +23,13 @@ __start:
     msr CPSR_c, r0
     ldr sp, =0x03007F00
 
+    @ Sets WAITCNT to the default used by GBA games
+    @
+    @ See https://problemkaputt.de/gbatek.htm#gbasystemcontrol for reference.
+    ldr r0, =0x04000204
+    ldr r1, =0x4317
+    str r1, [r0]
+
     @ copy .data and .text_iwram section to IWRAM
     ldr r0, =__iwram_lma     @ source address
     ldr r1, =__iwram_start   @ destination address


### PR DESCRIPTION
This sets the WAITCNT to the recommended value in GBATEK in `rsrt0.S` (setting the number of clock cycles needed to access the cartridge, and enabling prefetch).

At least on mgba (no idea how accurate the cycle counts are), this improves the amount of time `test_savegame` takes from 20.190 seconds to 12.966 seconds (35% improvement).