### PR TITLE
Include `iwram` section in linker script

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -29,6 +29,7 @@ SECTIONS {
         
         __text_iwram_start = ABSOLUTE(.);
         *(.text_iwram .text_iwram.*);
+        *(.iwram .iwram.*);
         . = ALIGN(4);
         __text_iwram_end = ABSOLUTE(.);
         


### PR DESCRIPTION
Fixes linking with [libseven](https://github.com/LunarLambda/libseven) (and probably other stuff?).