### PR TITLE
Use half-word write for WAITCNT access

### DIFF
--- a/src/rsrt0.S
+++ b/src/rsrt0.S
@@ -28,7 +28,7 @@ __start:
     @ See https://problemkaputt.de/gbatek.htm#gbasystemcontrol for reference.
     ldr r0, =0x04000204
     ldr r1, =0x4317
-    str r1, [r0]
+    strh r1, [r0]
 
     @ copy .data and .text_iwram section to IWRAM
     ldr r0, =__iwram_lma     @ source address


### PR DESCRIPTION
Fixes Stub I/O warning in mGBA.

```
[STUB] GBA I/O: Stub I/O register write: 206
```