### PR TITLE
Friendly interface for key inputs

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -43,7 +43,7 @@ pub fn main() -> ! {
 
   loop {
     // read our keys for this frame
-    let keys: Keys = KEYINPUT.read().into();
+    let keys: Keys = Keys::read();
 
     // adjust game state and wait for vblank
     px = px.wrapping_add((2 * keys.x_signum()) as usize);

--- a/examples/irq.rs
+++ b/examples/irq.rs
@@ -49,7 +49,7 @@ fn main() -> ! {
   start_timers();
 
   loop {
-    let this_frame_keys: Keys = KEYINPUT.read().into();
+    let this_frame_keys: Keys = Keys::read();
 
     // The VBlank IRQ must be enabled at minimum, or else the CPU will halt
     // at the call to vblank_interrupt_wait() as the VBlank IRQ will never

--- a/examples/keypad.rs
+++ b/examples/keypad.rs
@@ -35,7 +35,7 @@ pub fn main() -> ! {
   const RED: Color = Color::from_rgb(31, 0, 0);
   const GREEN: Color = Color::from_rgb(0, 31, 0);
 
-  let mut keys = Keys::new();
+  let mut keys = Keys::read();
 
   fn draw_square(x: usize, y: usize, color: Color) {
     mode3::bitmap_xy(x, y).write(color);
@@ -69,6 +69,6 @@ pub fn main() -> ! {
     draw_square(50, mode3::HEIGHT / 2, if keys.right() { GREEN } else { RED });
 
     // read our keys for next frame
-    keys = KEYINPUT.read().into();
+    keys.update();
   }
 }

--- a/src/mmio_types/keys.rs
+++ b/src/mmio_types/keys.rs
@@ -1,6 +1,6 @@
-use core::ops::BitOr;
-use crate::mmio_addresses::KEYINPUT;
 use super::*;
+use crate::mmio_addresses::KEYINPUT;
+use core::ops::BitOr;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[repr(transparent)]
@@ -22,16 +22,16 @@ impl KeysLowActive {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum Key {
-  A      = 1u16 << 0,
-  B      = 1u16 << 1,
+  A = 1u16 << 0,
+  B = 1u16 << 1,
   SELECT = 1u16 << 2,
-  START  = 1u16 << 3,
-  RIGHT  = 1u16 << 4,
-  LEFT   = 1u16 << 5,
-  UP     = 1u16 << 6,
-  DOWN   = 1u16 << 7,
-  R      = 1u16 << 8,
-  L      = 1u16 << 9,
+  START = 1u16 << 3,
+  RIGHT = 1u16 << 4,
+  LEFT = 1u16 << 5,
+  UP = 1u16 << 6,
+  DOWN = 1u16 << 7,
+  R = 1u16 << 8,
+  L = 1u16 << 9,
 }
 
 impl BitOr<Key> for Key {
@@ -91,7 +91,7 @@ impl Keys {
       0
     }
   }
-  
+
   pub fn any_pressed(self, key_mask: u16) -> bool {
     self.0 & key_mask != 0
   }
@@ -125,10 +125,7 @@ pub struct KeyMonitor {
 
 impl KeyMonitor {
   pub fn new() -> KeyMonitor {
-    KeyMonitor {
-      current: Keys::read(),
-      previous: Keys::default(),
-    }
+    KeyMonitor { current: Keys::read(), previous: Keys::default() }
   }
 
   pub fn update(&mut self) {


### PR DESCRIPTION
👋 Hello! I'm relatively new to Rust and gradually refreshing my memory of GBA programming (it's been about a decade!). I've been messing around with this library and thought I might contribute back some of the key input abstractions I wrote if this is the sort of thing you're looking for.

This branch adds:

  - A typed `Keys::read()` function to eliminate the need for `.into()`s (closes #130)
  - An `.update()` method to update a `Keys` in place
  - A `Key` enum with `BitOr` impls so you can do things like `if keys.any_pressed(Key::A | Key::B) { ... }`
  - A type for keeping track of key inputs across 2 frames. I called this `KeyMonitor`, but I'm definitely open to other thoughts on naming—I don't like calling something a "monitor" when it has to be manually updated, but I also didn't have a better idea.