### PR TITLE
Fix the memset/memclr pointer alignment

### DIFF
--- a/src/mem_fns.rs
+++ b/src/mem_fns.rs
@@ -451,6 +451,7 @@ pub unsafe extern "C" fn __aeabi_memset(
       "lsls   r12, r0, #31",
       "submi  r1, r1, #1",
       "strbmi r2, [r0], #1",
+      "lsls   r12, r0, #31",
       "subcs  r1, r1, #2",
       "strhcs r2, [r0], #2",
 


### PR DESCRIPTION
Here is another crash I encountered at some point, with an mgba trace to explain the issue.

I don't have much experience writing assembly, so there might be better fixes, but hopefully this should at least help explaining the issue, as it did fix that crash for me.

The trace was gathered with v0.10.0 and I rebased the fix.

```
03007D28 FFFFFFE8 00000000 00000000 03007D60 03007EB0 03007DC4 02000148 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002EC2 cpsr: 4000003F |     0034: lsl r4, r6, #0
03007D28 FFFFFFE8 00000000 00000000 03007DC4 03007EB0 03007DC4 02000148 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002EC4 cpsr: 0000003F |     2700: mov r7, #0
03007D28 FFFFFFE8 00000000 00000000 03007DC4 03007EB0 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002EC6 cpsr: 4000003F |     97FD: str r7, [sp, #1012]
03007D28 FFFFFFE8 00000000 00000000 03007DC4 03007EB0 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002EC8 cpsr: 4000003F |     97FC: str r7, [sp, #1008]
03007D28 FFFFFFE8 00000000 00000000 03007DC4 03007EB0 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002ECA cpsr: 4000003F |     97FB: str r7, [sp, #1004]
03007D28 FFFFFFE8 00000000 00000000 03007DC4 03007EB0 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002ECC cpsr: 4000003F |     97FA: str r7, [sp, #1000]
03007D28 FFFFFFE8 00000000 00000000 03007DC4 03007EB0 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002ECE cpsr: 4000003F |     97F9: str r7, [sp, #996]
03007D28 FFFFFFE8 00000000 00000000 03007DC4 03007EB0 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002ED0 cpsr: 4000003F |     A8E0: add r0, sp, #896
03007C88 FFFFFFE8 00000000 00000000 03007DC4 03007EB0 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002ED2 cpsr: 4000003F |     1CC0: add r0, r0, #3`
# Set start address to 0x03007C8B
03007C8B FFFFFFE8 00000000 00000000 03007DC4 03007EB0 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002ED4 cpsr: 0000003F |     2555: mov r5, #85
# Set memset size to 0x55
03007C8B FFFFFFE8 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002ED6 cpsr: 0000003F |     0029: lsl r1, r5, #0
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EC1 08002ED8 cpsr: 0000003F | F041F85B: bl
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08043EDA 08002EDA cpsr: 0000003F |     F85B: bl
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 08043F92 cpsr: 0000003F |     4778: bx pc
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 08043F98 cpsr: 0000001F | E51FF004: ldr pc, =0xE51FF004  @ 0x08043F94
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 030006DC cpsr: 0000001F | E3A02000: mov r2, #0
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 030006E0 cpsr: 0000001F | E20220FF: and r2, r2, #255
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 030006E4 cpsr: 0000001F | E1822402: orr r2, r2, r2, lsl #8
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 030006E8 cpsr: 0000001F | E1822802: orr r2, r2, r2, lsl #16
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 030006EC cpsr: 0000001F | E1A03002: mov r3, r2
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 030006F0 cpsr: 0000001F | E3510003: cmp r1, #3
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 030006F4 cpsr: 2000001F | DA00001D: ble 0x03000768
# The address is r0 needs to be 4-byte aligned (last two bits must be 0), first deal with bit 0 by checking if it's 1
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 00000000 03007908 08002EDB 030006F8 cpsr: 2000001F | E1B0CF80: movs r12, r0, lsl #31
# The address is odd, reduce r1 by 1 and store r2 in r0 increasing the pointer by 1
03007C8B 00000055 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 030006FC cpsr: A000001F | 42411001: submi r1, r1, #1
03007C8B 00000054 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 03000700 cpsr: A000001F | 44C02001: strmib r2, [r0], #1
# This should check if r0 is now (!) a multiple of 2 but not 4 (if bit 1 is 1), but the issue is that it was when the flags were updated, and now it is not anymore because we increased it by 1
# The address is thus already 4-byte aligned, but since the C flag is still 1, this pushes r0 by 2 bytes and the address becomes unaligned
# My understanding is that it should re-flag r0 here to behave as expected.
03007C8C 00000054 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 03000704 cpsr: A000001F | 22411002: subcs r1, r1, #2
03007C8C 00000052 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 03000708 cpsr: A000001F | 20C020B2: strcsh r2, [r0], #2
03007C8E 00000052 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 0300070C cpsr: A000001F | E3510020: cmp r1, #32
03007C8E 00000052 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 03000710 cpsr: 2000001F | AA000009: bge 0x03000734
# This starts doing stm instructions on an unaligned address
03007C8E 00000052 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 0300073C cpsr: 2000001F | E92D03F0: stmdb sp!, {r4-r9}
03007C8E 00000052 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000740 cpsr: 2000001F | E1A04002: mov r4, r2
03007C8E 00000052 00000000 00000000 00000000 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000744 cpsr: 2000001F | E1A05002: mov r5, r2
03007C8E 00000052 00000000 00000000 00000000 00000000 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000748 cpsr: 2000001F | E1A06002: mov r6, r2
03007C8E 00000052 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 0300074C cpsr: 2000001F | E1A07002: mov r7, r2
03007C8E 00000052 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000750 cpsr: 2000001F | E1A08002: mov r8, r2
03007C8E 00000052 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000754 cpsr: 2000001F | E1A09002: mov r9, r2
03007C8E 00000052 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000758 cpsr: 2000001F | E2511020: subs r1, r1, #32
03007C8E 00000032 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 0300075C cpsr: 2000001F | A8A003FC: stmgeia r0!, {r2-r9}
03007CAE 00000032 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000760 cpsr: 2000001F | CAFFFFFC: bgt 0x03000750
03007CAE 00000032 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000758 cpsr: 2000001F | E2511020: subs r1, r1, #32
03007CAE 00000012 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 0300075C cpsr: 2000001F | A8A003FC: stmgeia r0!, {r2-r9}
03007CCE 00000012 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000760 cpsr: 2000001F | CAFFFFFC: bgt 0x03000750
03007CCE 00000012 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000758 cpsr: 2000001F | E2511020: subs r1, r1, #32
03007CCE FFFFFFF2 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 0300075C cpsr: 8000001F | A8A003FC: stmgeia r0!, {r2-r9}
03007CCE FFFFFFF2 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000760 cpsr: 8000001F | CAFFFFFC: bgt 0x03000750
03007CCE FFFFFFF2 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 80000000 030078F0 08002EDB 03000764 cpsr: 8000001F | E8BD03F0: ldmia sp!, {r4-r9}
03007CCE FFFFFFF2 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 03000768 cpsr: 8000001F | 012FFF1E: bxeq lr
03007CCE FFFFFFF2 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 0300076C cpsr: 8000001F | EAFFFFE8: b 0x0300070C
03007CCE FFFFFFF2 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 03000714 cpsr: 8000001F | E3110010: tst r1, #16
03007CCE FFFFFFF2 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 03000718 cpsr: 0000001F | 18A0000C: stmneia r0!, {r2-r3}
# stmneia only seem to support aligned addresses: https://developer.arm.com/documentation/den0013/d/Porting/Alignment
# but 0x03007CD6 is not aligned so it seems to start writing at 0x03007CD4 and misses the last 2 bytes.
# Maybe the shifted count accounts for the other 2 bytes missing after (0X03007CDE and 0X03007CDF)? Not sure, but fixing the start of the memset fixed it for me.
03007CD6 FFFFFFF2 00000000 00000000 03007DC4 00000055 03007DC4 00000000 00000000 00000000 00000000 00000000 80000000 03007908 08002EDB 0300071C cpsr: 0000001F | 18A0000C: stmneia r0!, {r2-r3}
Hit watchpoint 4 at 0x03007CDA: (new value = 0x00000000, old value = 0x00080000)
 r0: 03007CDE   r1: FFFFFFF2   r2: 00000000   r3: 00000000
 r4: 03007DC4   r5: 00000055   r6: 03007DC4   r7: 00000000
 r8: 00000000   r9: 00000000  r10: 00000000  r11: 00000000
r12: 80000000  r13: 03007908  r14: 08002EDB  r15: 03000720
cpsr: 0000001F [-------]
Cycle: 14610
0300071C:  E1B0CE81 movs r12, r1, lsl #29
# The last byte address to be set to 0 should have been 0x03007C8B+0x55-1=0X03007CDF, but the byte at 0x03007CDC itself is still 0x04
> x/4 0x03007CD4
0x03007CD4: 00000000 00000000 00000004 030008C8
> x/4 0x03007CDC
0x03007CDC: 00000004 030008C8 08019677 00000001
```