### PR TITLE
Push and pop registers in system mode within IRQ handler.

### DIFF
--- a/src/asm_runtime.rs
+++ b/src/asm_runtime.rs
@@ -149,11 +149,11 @@ core::arch::global_asm! {
     "ldr r12, [r12]",
     bracer::when!(("r12" != "#0")[1] {
       bracer::a32_read_spsr_to!("r3"),
-      "push {{r3, lr}}",
       bracer::a32_set_cpu_control!(System, irq_masked = true, fiq_masked = true),
+      "push {{r3, lr}}",
       bracer::a32_fake_blx!("r12"),
-      bracer::a32_set_cpu_control!(IRQ, irq_masked = true, fiq_masked = true),
       "pop {{r3, lr}}",
+      bracer::a32_set_cpu_control!(IRQ, irq_masked = true, fiq_masked = true),
       bracer::a32_write_spsr_from!("r3"),
     }),
 


### PR DESCRIPTION
Fixes #198.

After comparing the IRQ handler, the only difference I could see was that registers were pushed and popped within System mode in `0.12`, and they were not in `0.13`. Apparently mgba (and no$gba, which I also tested against while debugging) works just fine either way, but running on real hardware does not work correctly.

I don't know the exact technical reason for why this way works and the other doesn't, but this at least gets us back to the same functionality that was present before #197.

By the way, for future reference, my process here was to add another dependency on the old bracer version (using `bracer_1_2 = {package = "bracer", version  = "=0.1.2"}` in `Cargo.toml`, and manually injecting the yanked version into `Cargo.lock`), replacing the relevant IRQ code with what existed in version `0.12.0`, and verifying that it worked on hardware (which it did). Then I just replaced each `bracer_1_2` macro call with the `bracer 0.3.1` equivalent until I found the change that no longer worked on hardware.