### PR TITLE
Update README.md to remove legacy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 This crate is intended for working with the GBA.
 
-To build for the GBA you'll need to use `build-std` and you'll also need to
-activate the `compiler-builtins-weak-intrinsics` feature.
+To build for the GBA you'll need to use `build-std`.
 
 The following should be somewhere in your `.cargo/config.toml`:
 
 ```toml
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-weak-intrinsics"]
 ```


### PR DESCRIPTION
This was removed from the `.cargo/config.toml` 5 months ago in 67659f5.