### PR TITLE
generalize Align4::as_slice for any Sized type with appropriate alignment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,9 @@ use prelude::{GbaCell, IrqFn};
 
 mod macros;
 
+#[cfg(test)]
+mod test_harness;
+
 #[cfg(feature = "on_gba")]
 mod asm_runtime;
 #[cfg(feature = "on_gba")]
@@ -181,121 +184,6 @@ macro_rules! include_aligned_bytes {
   ($file:expr $(,)?) => {{
     Align4(*include_bytes!($file))
   }};
-}
-
-#[cfg(test)]
-mod test_harness {
-  use crate::prelude::*;
-  use crate::{bios, mem, mgba};
-  use core::fmt::Write;
-
-  #[panic_handler]
-  fn panic(info: &core::panic::PanicInfo) -> ! {
-    DISPSTAT.write(DisplayStatus::new().with_irq_vblank(true));
-    BG_PALETTE.index(0).write(Color::from_rgb(25, 10, 5));
-    IE.write(IrqBits::VBLANK);
-    IME.write(true);
-    VBlankIntrWait();
-    VBlankIntrWait();
-    VBlankIntrWait();
-
-    // the Fatal one kills emulation after one line / 256 bytes
-    // so emit all the information as Error first
-    if let Ok(mut log) =
-      mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Error)
-    {
-      writeln!(log, "[failed]").ok();
-      write!(log, "{}", info).ok();
-    }
-
-    if let Ok(mut log) =
-      mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Fatal)
-    {
-      if let Some(loc) = info.location() {
-        write!(log, "panic at {loc}! see mgba error log for details.").ok();
-      } else {
-        write!(log, "panic! see mgba error log for details.").ok();
-      }
-    }
-
-    IE.write(IrqBits::new());
-    bios::IntrWait(true, IrqBits::new());
-    loop {}
-  }
-
-  pub(crate) trait UnitTest {
-    fn run(&self);
-  }
-
-  impl<T: Fn()> UnitTest for T {
-    fn run(&self) {
-      if let Ok(mut log) =
-        mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Info)
-      {
-        write!(log, "{}...", core::any::type_name::<T>()).ok();
-      }
-
-      self();
-
-      if let Ok(mut log) =
-        mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Info)
-      {
-        writeln!(log, "[ok]").ok();
-      }
-    }
-  }
-
-  pub(crate) fn test_runner(tests: &[&dyn UnitTest]) {
-    if let Ok(mut log) =
-      mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Info)
-    {
-      write!(log, "Running {} tests", tests.len()).ok();
-    }
-
-    for test in tests {
-      test.run();
-    }
-    if let Ok(mut log) =
-      mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Info)
-    {
-      write!(log, "Tests finished successfully").ok();
-    }
-  }
-
-  #[no_mangle]
-  extern "C" fn main() {
-    DISPCNT.write(DisplayControl::new().with_video_mode(VideoMode::_0));
-    BG_PALETTE.index(0).write(Color::new());
-
-    crate::test_main();
-
-    BG_PALETTE.index(0).write(Color::from_rgb(5, 15, 25));
-    BG_PALETTE.index(1).write(Color::new());
-    BG0CNT
-      .write(BackgroundControl::new().with_charblock(0).with_screenblock(31));
-    DISPCNT.write(
-      DisplayControl::new().with_video_mode(VideoMode::_0).with_show_bg0(true),
-    );
-
-    // some niceties for people without mgba-test-runner
-    let tsb = TEXT_SCREENBLOCKS.get_frame(31).unwrap();
-    unsafe {
-      mem::set_u32x80_unchecked(
-        tsb.into_block::<1024>().as_mut_ptr().cast(),
-        0,
-        12,
-      );
-    }
-    Cga8x8Thick.bitunpack_4bpp(CHARBLOCK0_4BPP.as_region(), 0);
-
-    let row = tsb.get_row(9).unwrap().iter().skip(6);
-    for (addr, ch) in row.zip(b"all tests passed!") {
-      addr.write(TextEntry::new().with_tile(*ch as u16));
-    }
-
-    DISPSTAT.write(DisplayStatus::new());
-    bios::IntrWait(true, IrqBits::new());
-  }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,9 +327,15 @@ mod test {
     struct ThreeHalfWords(u16, u16, u16);
 
     assert_eq!(
-      Align4([0x11u8, 0x11u8, 0x22u8, 0x22u8, 0x33u8, 0x33u8])
-        .as_slice::<ThreeHalfWords>(),
-      &[ThreeHalfWords(0x1111, 0x2222, 0x3333)]
+      Align4([
+        0x11u8, 0x11u8, 0x22u8, 0x22u8, 0x33u8, 0x33u8, 0x44u8, 0x44u8, 0x55u8,
+        0x55u8, 0x66u8, 0x66u8
+      ])
+      .as_slice::<ThreeHalfWords>(),
+      &[
+        ThreeHalfWords(0x1111, 0x2222, 0x3333),
+        ThreeHalfWords(0x4444, 0x5555, 0x6666)
+      ]
     );
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,4 +308,28 @@ mod test {
     assert_eq!(a.as_u16_slice(), &[0x100_u16.to_le(), 0x302_u16.to_le()]);
     assert_eq!(a.as_u32_slice(), &[0x3020100_u32.to_le()]);
   }
+
+  #[test_case]
+  fn align4_as_generic() {
+    // with padding
+    #[repr(C, align(4))]
+    #[derive(PartialEq, Debug)]
+    struct FiveByte([u8; 5]);
+
+    assert_eq!(
+      Align4(*b"hello...world...").as_slice::<FiveByte>(),
+      &[FiveByte(*b"hello"), FiveByte(*b"world")]
+    );
+
+    // and without
+    #[repr(C, align(2))]
+    #[derive(PartialEq, Debug)]
+    struct ThreeHalfWords(u16, u16, u16);
+
+    assert_eq!(
+      Align4([0x11u8, 0x11u8, 0x22u8, 0x22u8, 0x33u8, 0x33u8])
+        .as_slice::<ThreeHalfWords>(),
+      &[ThreeHalfWords(0x1111, 0x2222, 0x3333)]
+    );
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ impl<const N: usize> Align4<[u8; N]> {
   #[must_use]
   pub const fn as_slice<T: Sized>(&self) -> &[T] {
     const {
-      assert!(N % size_of::<T>() == 0);
+      assert!(N % (size_of::<T>() + (size_of::<T>() % align_of::<T>())) == 0);
       assert!(
         align_of::<T>() == 4 || align_of::<T>() == 2 || align_of::<T>() == 1
       );

--- a/src/test_harness.rs
+++ b/src/test_harness.rs
@@ -1,0 +1,109 @@
+use crate::{bios, mem, mgba, prelude::*};
+use core::fmt::Write;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+  DISPSTAT.write(DisplayStatus::new().with_irq_vblank(true));
+  BG_PALETTE.index(0).write(Color::from_rgb(25, 10, 5));
+  IE.write(IrqBits::VBLANK);
+  IME.write(true);
+  VBlankIntrWait();
+  VBlankIntrWait();
+  VBlankIntrWait();
+
+  // the Fatal one kills emulation after one line / 256 bytes
+  // so emit all the information as Error first
+  if let Ok(mut log) =
+    mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Error)
+  {
+    writeln!(log, "[failed]").ok();
+    write!(log, "{}", info).ok();
+  }
+
+  if let Ok(mut log) =
+    mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Fatal)
+  {
+    if let Some(loc) = info.location() {
+      write!(log, "panic at {loc}! see mgba error log for details.").ok();
+    } else {
+      write!(log, "panic! see mgba error log for details.").ok();
+    }
+  }
+
+  IE.write(IrqBits::new());
+  bios::IntrWait(true, IrqBits::new());
+  loop {}
+}
+
+pub(crate) trait UnitTest {
+  fn run(&self);
+}
+
+impl<T: Fn()> UnitTest for T {
+  fn run(&self) {
+    if let Ok(mut log) =
+      mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Info)
+    {
+      write!(log, "{}...", core::any::type_name::<T>()).ok();
+    }
+
+    self();
+
+    if let Ok(mut log) =
+      mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Info)
+    {
+      writeln!(log, "[ok]").ok();
+    }
+  }
+}
+
+pub(crate) fn test_runner(tests: &[&dyn UnitTest]) {
+  if let Ok(mut log) =
+    mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Info)
+  {
+    write!(log, "Running {} tests", tests.len()).ok();
+  }
+
+  for test in tests {
+    test.run();
+  }
+  if let Ok(mut log) =
+    mgba::MgbaBufferedLogger::try_new(mgba::MgbaMessageLevel::Info)
+  {
+    write!(log, "Tests finished successfully").ok();
+  }
+}
+
+#[no_mangle]
+extern "C" fn main() {
+  DISPCNT.write(DisplayControl::new().with_video_mode(VideoMode::_0));
+  BG_PALETTE.index(0).write(Color::new());
+
+  crate::test_main();
+
+  BG_PALETTE.index(0).write(Color::from_rgb(5, 15, 25));
+  BG_PALETTE.index(1).write(Color::new());
+  BG0CNT.write(BackgroundControl::new().with_charblock(0).with_screenblock(31));
+  DISPCNT.write(
+    DisplayControl::new().with_video_mode(VideoMode::_0).with_show_bg0(true),
+  );
+
+  // some niceties for people without mgba-test-runner
+  let tsb = TEXT_SCREENBLOCKS.get_frame(31).unwrap();
+  unsafe {
+    mem::set_u32x80_unchecked(
+      tsb.into_block::<1024>().as_mut_ptr().cast(),
+      0,
+      12,
+    );
+  }
+  Cga8x8Thick.bitunpack_4bpp(CHARBLOCK0_4BPP.as_region(), 0);
+
+  let row = tsb.get_row(9).unwrap().iter().skip(6);
+  for (addr, ch) in row.zip(b"all tests passed!") {
+    addr.write(TextEntry::new().with_tile(*ch as u16));
+  }
+
+  DISPSTAT.write(DisplayStatus::new());
+  bios::IntrWait(true, IrqBits::new());
+}


### PR DESCRIPTION
also move the assertions to compile-time because we know what we need to know by then