### PR TITLE
Specify `--lib` so cargo only runs tests defined in lib, not doc examples

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -55,3 +55,4 @@ jobs:
         with:
           toolchain: ${{ matrix.rust.toolchain }}
           command: test
+          args: --lib


### PR DESCRIPTION
Addresses issue #216