### PR TITLE
Optionally include global ASM runtime (to allow using gba-rs as a lib)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 license = "Zlib OR Apache-2.0 OR MIT"
 
 [features]
-default = ["track_caller", "on_gba"]
+default = ["track_caller", "on_gba", "asm_runtime"]
+asm_runtime = []
 track_caller = []
 on_gba = []
 fixed = ["dep:fixed"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ mod macros;
 #[cfg(test)]
 mod test_harness;
 
-#[cfg(feature = "on_gba")]
+#[cfg(feature = "asm_runtime")]
 mod asm_runtime;
 #[cfg(feature = "on_gba")]
 pub mod bios;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,9 +2,11 @@
 
 #[cfg(feature = "on_gba")]
 pub use crate::{
-  asm_runtime::*, bios::*, dma::*, gba_cell::*, mgba::*, mmio::*,
-  RUST_IRQ_HANDLER,
+  bios::*, dma::*, gba_cell::*, mgba::*, mmio::*, RUST_IRQ_HANDLER,
 };
+
+#[cfg(feature = "asm_runtime")]
+pub use crate::asm_runtime::*;
 
 pub use crate::{
   builtin_art::*,


### PR DESCRIPTION
Howdy!

I was messing around with compiling Rust for GBA while creating binaries to test my recent [USB Multiboot project](https://github.com/nullstalgia/gbasend-rs) (and it's [speed test binary](https://github.com/nullstalgia/gbasend-rs/tree/main/gbasend-lib/speed-test-gba)), and the pre-defined `VolatileAddress`s and their bespoke types (like `IrqBits`) are super handy to use outside of using `gba` as a game engine.

However, since it assumes it's the only global ASM crate, I can't use it for Multiboot projects due to a cartridge-assuming runtime, and the space supplied for the header not having enough room. Additionally, I can't use its predefined addresses and types in a project that is properly set up, for the same reason (the global ASM runtime).

So I chose to make it entirely optional while working on my aforementioned speed test binary, using my own runtime while still using `gba`'s types.

I still had to make my own consts `GBA_BIOS_IRQ_HANDLER @ 0x03007FFC` and `GBA_BIOS_IF @ 0x03007DF8` bindings, but it worked well!

If you'd like assistance in making `gba` Multiboot-compatible, I'd be very willing to lend a hand!